### PR TITLE
Update plugin.js

### DIFF
--- a/lineheight/plugin.js
+++ b/lineheight/plugin.js
@@ -3,7 +3,7 @@
 
         editor.on('init', function () {
             editor.formatter.register({
-                lineheight: {inline: 'span', styles: {'line-height': '%value'}}
+                lineheight: {selector: 'p,h1,h2,h3,h4,h5,h6', styles: {'line-height': '%value'}}
             });
         });
 


### PR DESCRIPTION
Updated the lineheight format object that is registered in the Editor Formatter, so the line-height is applied to paragraphs, and headings from 1 to 6 as a style attribute. (before a span tag was added, whereas line-height should be applied to block elements)
